### PR TITLE
Add ability to write bad rings.

### DIFF
--- a/src/Arrays/param.cpp
+++ b/src/Arrays/param.cpp
@@ -541,6 +541,7 @@ void Param::setParam(string &parstr) {
     if(arg=="plotmask")  parGF.PLOTMASK   = readFlag(ss);
     if(arg=="reverse")   parGF.REVERSE    = makelower(readFilename(ss));
     if(arg=="normalcube")parGF.NORMALCUBE = readFlag(ss);
+    if(arg=="badout")    parGF.flagBADOUT     = readFlag(ss);
 
 
     // GALWIND ONLY PARAMETERS
@@ -1339,6 +1340,7 @@ void printParams(std::ostream& Str, Param &p, bool defaults, string whichtask) {
             recordParam(Str, "[PLOTMASK]", "   Overlaying mask to output plots?", stringize(p.getParGF().PLOTMASK));
             recordParam(Str, "[REVERSE]", "   Using reverse-cumulative fitting?", p.getParGF().REVERSE);
             recordParam(Str, "[NORMALCUBE]", "   Normalizing cube to help convergence?", stringize(p.getParGF().NORMALCUBE));
+	    recordParam(Str, "[BADOUT]", "   Write unconverged rings in output (with flag)?", stringize(p.getParGF().flagBADOUT));
 
         }
 

--- a/src/Arrays/param.hh
+++ b/src/Arrays/param.hh
@@ -84,6 +84,7 @@ struct GALFIT_PAR : GALMOD_PAR {
     bool   PLOTMASK   = false;    ///< Whether to show the mask in output plots
     string REVERSE    = "auto";   ///< Whether to use a reverse cumulative fitting.
     bool   NORMALCUBE = true;     ///< Whether to normalize the input flux values.
+    bool   flagBADOUT = false;    ///< Whether to write bad rings (with flag) in output.
     
 };
 

--- a/src/Tasks/galfit.hh
+++ b/src/Tasks/galfit.hh
@@ -159,9 +159,9 @@ protected:
 
 
 /// Some function to conveniently write Galfit rings
-void writeHeader(std::ostream &fout, bool *mpar, bool writeErrors);
+void writeHeader(std::ostream &fout, bool *mpar, bool writeErrors, bool writeBadRings);
 template <class T>
-void writeRing(std::ostream &fout, Rings<T> *r, int i, double toKpc, int nfree, bool writeErrors, T ***errors);
+void writeRing(std::ostream &fout, Rings<T> *r, int i, double toKpc, int nfree, bool writeErrors, T ***errors, bool writeBadRings, bool fitOK);
 template <class T>
 void printRing(std::ostream &fout, Rings<T> *r, int i, double minimum, double toKpc, bool *mpar, int nthreads);
 


### PR DESCRIPTION
I've added a new feature that I've wanted for a while. It adds a new parameter for `3DFIT` called `BADOUT` (default: `FALSE`). If this parameter is set, rings which fail to converge, etc., will still be written to the output files (with bad values). A new column `FITOK` will also be added to the output, which will be `1` for rings which succeeded and `0` for rings which failed. This makes automatically checking for failed rings easier (previously, either needed to check the ring radii against a list of expected rings, or attempt to parse the stdout messages).

Note that I've only implemented the basics: recognise the new parameter when parsing the parameter file, and decide whether to write extra output to file. I haven't updated documentation, or the pyBB interface, which I guess should be done before merging...