### PR TITLE
Nautilus + static sampler

### DIFF
--- a/pyBBarolo/bayesian.py
+++ b/pyBBarolo/bayesian.py
@@ -25,7 +25,7 @@ import scipy.stats
 from .BB_interface import libBB
 from .pyBBarolo import Param, Rings, FitMod3D, reshapePointer
 
-from dynesty import DynamicNestedSampler
+from dynesty import DynamicNestedSampler, NestedSampler
 from dynesty.utils import resample_equal
 
 import nautilus
@@ -229,11 +229,10 @@ class BayesianBBarolo(FitMod3D):
 
         # Now fitting
         if method=='dynesty':
-            self.sampler = DynamicNestedSampler(log_likelihood, prior_transform, ndim=self.ndim, \
-                                                bound='multi',pool=pool,**sampler_kwargs)
-            toc = time.time()
+            DynestySampler = DynamicNestedSampler if kwargs.get('dynamic',True) else NestedSampler
+            self.sampler = DynestySampler(log_likelihood, prior_transform, ndim=self.ndim, \
+                                                    bound='multi',pool=pool,**sampler_kwargs)
             self.sampler.run_nested(print_progress=verbose,**run_kwargs)
-            tic = time.time(); dt = tic-toc
 
             self.results = self.sampler.results
 


### PR DESCRIPTION
It's me, again 🙂

I integrated the `nautilus` sampler (see [here](https://nautilus-sampler.readthedocs.io/en/latest/#)) in `bayesian.py`, along with the static nested sampler in `dynesty`. After a quick test, the former seems to be around  x2 faster than `dynesty`'s dynamic nested sampling, and as fast as the static version (but allows for a better posterior sampling than the static case).

The nautilus sampler can be invoked simply passing the `method='nautilus'` argument to `compute`.