### PR TITLE
minor fixes + memory leak

### DIFF
--- a/pyBBarolo/bayesian.py
+++ b/pyBBarolo/bayesian.py
@@ -232,19 +232,16 @@ class BayesianBBarolo(FitMod3D):
             DynestySampler = DynamicNestedSampler if kwargs.get('dynamic',True) else NestedSampler
             self.sampler = DynestySampler(log_likelihood, prior_transform, ndim=self.ndim, \
                                                     bound='multi',pool=pool,**sampler_kwargs)
+            tic = time.time()
             self.sampler.run_nested(print_progress=verbose,**run_kwargs)
+            tic = time.time(); dt = tic-toc
 
             self.results = self.sampler.results
 
             # Extract the best-fit parameters
-            samples = self.results.samples  # Posterior samples
+            self.samples = self.results.samples  # Posterior samples
             weights = np.exp(self.results.logwt - self.results.logz[-1])
-            params = np.average(samples, axis=0, weights=weights)
-            
-            self.samples = resample_equal(samples,weights)
-            
-            self.params = params
-        
+                                
         elif method=='nautilus':
             if 'dlogz' in run_kwargs and 'f_live' not in run_kwargs:
                 run_kwargs['f_live'] = run_kwargs.pop('dlogz')
@@ -255,14 +252,13 @@ class BayesianBBarolo(FitMod3D):
             self.sampler.run(verbose=verbose,**run_kwargs)
             tic = time.time(); dt = tic-toc
 
-            # @TODO: we should probably make the output uniform with
-            #        all the other methods.
-            self.samples, log_w, _ = self.sampler.posterior()
-            self.samples = resample_equal(self.samples,np.exp(log_w))
-
-            self.params = np.average(self.samples,axis=0)
+            self.samples, weights, _ = self.sampler.posterior()
+            weights = np.exp(weights-weights.max())
         else: 
             raise ValueError(f"ERROR! Unknown method {method}.")
+
+        self.samples = resample_equal(self.samples,weights)
+        self.params = np.average(self.samples,axis=0)
 
         dt = f'{dt:.2f} seconds' if dt<60.00 else f'{dt/60.00:.2f} minutes' 
         print(f'Sampling with {method} took {dt} to run.')

--- a/pyBBarolo/bayesian.py
+++ b/pyBBarolo/bayesian.py
@@ -258,7 +258,7 @@ class BayesianBBarolo(FitMod3D):
             raise ValueError(f"ERROR! Unknown method {method}.")
 
         self.samples = resample_equal(self.samples,weights)
-        self.params = np.average(self.samples,axis=0)
+        self.params = np.median(self.samples,axis=0)
 
         dt = f'{dt:.2f} seconds' if dt<60.00 else f'{dt/60.00:.2f} minutes' 
         print(f'Sampling with {method} took {dt} to run.')

--- a/pyBBarolo/bayesian.py
+++ b/pyBBarolo/bayesian.py
@@ -243,7 +243,7 @@ class BayesianBBarolo(FitMod3D):
             
             self.samples = resample_equal(samples,weights)
             
-            print (params)
+            self.params = params
         
         elif method=='nautilus':
             if 'dlogz' in run_kwargs and 'f_live' not in run_kwargs:
@@ -259,7 +259,8 @@ class BayesianBBarolo(FitMod3D):
             #        all the other methods.
             self.samples, log_w, _ = self.sampler.posterior()
             self.samples = resample_equal(self.samples,np.exp(log_w))
-        
+
+            self.params = np.average(self.samples,axis=0)
         else: 
             raise ValueError(f"ERROR! Unknown method {method}.")
 

--- a/pyBBarolo/pyBBarolo.py
+++ b/pyBBarolo/pyBBarolo.py
@@ -25,6 +25,10 @@ import numpy as np
 from .BB_interface import libBB
 from astropy.io import fits
 
+import ctypes
+import ctypes.util
+libc_ = ctypes.util.find_library('c')
+libc  = ctypes.CDLL(libc_)
 
 def reshapePointer (p, shape):
     """Take a POINTER to c_float and reshape it.
@@ -37,9 +41,13 @@ def reshapePointer (p, shape):
       ndarray: The reshaped array
     
     """
-    return np.ctypeslib.as_array(p, shape=tuple(shape))
-
-
+   #return np.ctypeslib.as_array(p, shape=tuple(shape))
+    parray = np.ctypeslib.as_array(p,shape=tuple(shape))
+    carray = np.copy(parray)
+    
+    libc.free(p)
+    return carray
+    
 def isIterable (p):
     """Check if p is an iteratable (list,tuple or numpy array). """
     return isinstance(p,(list,tuple,np.ndarray))


### PR DESCRIPTION
This is mostly for having a uniform structure for both the `dynesty` and `nautilus` output.
Also, I changed the default for computing the best-fit parameters to the median instead of the mean.

EDIT:
I've just included a fix to a memory leak caused by the `ctypeslib` call inside `reshapePointer` (in `pyBBarolo.py`). This seems to solve the issue, but we should double check that's actually working.
Also, I am know using `ctypes.util.find_library` to find the reference C library automatically, but we should find a way to point to the one used for compiling BBarolo.